### PR TITLE
Update envrc

### DIFF
--- a/pkgs/nixify/envrc
+++ b/pkgs/nixify/envrc
@@ -30,6 +30,10 @@ use_nix() {
 	# define all local variables
 	local shell f env_hash dir default wd drv dump path_backup
 	local files_to_watch=()
+	
+	declare opt
+        declare OPTARG
+        declare OPTIND
 
 	while getopts ":s:w:" opt; do
 		case "${opt}" in


### PR DESCRIPTION
Had to declare opt, OPTARG and OPTIND to use getops within a function using zsh getopts. Otherwise no argumenst are iterated and SHELL is missing...