### PR TITLE
pkgs: rbrowser: fix profiles detection when no chrome profiles exist

### DIFF
--- a/pkgs/rbrowser/bin/rbrowser
+++ b/pkgs/rbrowser/bin/rbrowser
@@ -93,6 +93,7 @@ if [[ -z "${profile}" ]]; then
 		for i in $FIREFOX_PROFILES_PATH/*; do;
 			if [[ -d "${i}" ]]; then
 				items="${items}${sep}firefox@$(basename "${i}")"
+				sep="\n"
 			fi
 		done
 	fi


### PR DESCRIPTION
If no chromium profiles are found, firefox profiles are not separated, making it impossible to choose between them.