### PR TITLE
pkgs: stdenv.lib -> lib

### DIFF
--- a/pkgs/corgi/default.nix
+++ b/pkgs/corgi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoPackage, fetchFromGitHub }:
+{ lib, stdenv, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
   name = "corgi-${rev}";
@@ -15,7 +15,7 @@ buildGoPackage rec {
 
   goDeps = ./deps.nix;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "CLI workflow manager";
     longDescription = ''
       Corgi is a command-line tool that helps with your repetitive command usages by organizing them into reusable snippet.

--- a/pkgs/gocode/default.nix
+++ b/pkgs/gocode/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoPackage, fetchFromGitHub }:
+{ lib, stdenv, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
   name = "gocode-unstable-${version}";
@@ -28,7 +28,7 @@ buildGoPackage rec {
     rm -r go/src/$goPackagePath/internal/suggest/testdata
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "An autocompletion daemon for the Go programming language";
     longDescription = ''
       Gocode is a helper tool which is intended to be integrated with your

--- a/pkgs/ls-colors/default.nix
+++ b/pkgs/ls-colors/default.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
 stdenvNoCC.mkDerivation rec {
   name = "lscolors-unstable-${version}";
@@ -21,7 +21,7 @@ stdenvNoCC.mkDerivation rec {
     mv bourne-shell.sh c-shell.sh $out/ls-colors/
   '';
 
-  meta = with stdenvNoCC.lib; {
+  meta = with lib; {
     description = "A collection of LS_COLORS definitions; needs your contribution!";
     longDescription = ''
       This is a collection of extension:color mappings, suitable to use as your

--- a/pkgs/shrinkpdf/default.nix
+++ b/pkgs/shrinkpdf/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, stdenv, fetchurl }:
+{ lib, pkgs, stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
   name = "shrinkpdf-${version}";
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
       --replace gs ${pkgs.ghostscript}/bin/gs
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "shrink PDF files with Ghostscript";
     longDescription = ''
       A simple wrapper around Ghostscript to shrink PDFs (as in reduce


### PR DESCRIPTION
Following https://github.com/NixOS/nixpkgs/issues/108938 `stdenv.lib` is deprecated and does not evaluate with nixpkgs 21.11 and forward.